### PR TITLE
Orders後台 錯誤驗證/排程器/訂單狀態檢查/pom檔javax.validation更動

### DIFF
--- a/src/main/java/com/lifespace/LifeSpaceSprApplication.java
+++ b/src/main/java/com/lifespace/LifeSpaceSprApplication.java
@@ -1,8 +1,11 @@
 package com.lifespace;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class LifeSpaceSprApplication {
 

--- a/src/main/java/com/lifespace/controller/OrdersController.java
+++ b/src/main/java/com/lifespace/controller/OrdersController.java
@@ -2,6 +2,7 @@ package com.lifespace.controller;
 
 
 import com.lifespace.dto.OrdersDTO;
+import com.lifespace.entity.Orders;
 import com.lifespace.service.OrdersService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -18,7 +19,8 @@ public class OrdersController {
     private OrdersService ordersSvc;
 
     public OrdersController(OrdersService ordersSvc) {
-    this.ordersSvc = ordersSvc;
+
+        this.ordersSvc = ordersSvc;
     }
 
 
@@ -30,8 +32,14 @@ public class OrdersController {
 
     @PostMapping("/cancel/{orderId}")
     public ResponseEntity<String> cancelOrder(@PathVariable String orderId) {
-        ordersSvc.updateOrderStatusByOrderId(orderId); // 改變訂單狀態
-        return ResponseEntity.ok("success");
-    }
 
+        try {
+            ordersSvc.updateOrderStatusByOrderId(orderId); // 改變訂單狀態
+            return ResponseEntity.ok("已成功取消訂單" + orderId);
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            return ResponseEntity.badRequest().body(e.getMessage());
+        }
+    }
 }
+
+

--- a/src/main/java/com/lifespace/entity/Orders.java
+++ b/src/main/java/com/lifespace/entity/Orders.java
@@ -2,6 +2,7 @@ package com.lifespace.entity;
 
 import com.lifespace.entity.Event;
 import jakarta.persistence.*;
+import org.hibernate.annotations.GenericGenerator;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
@@ -11,6 +12,9 @@ import java.sql.Timestamp;
 public class Orders implements Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    @GeneratedValue(generator = "custom-id")
+    @GenericGenerator(name = "custom-id", strategy = "com.lifespace.util.OrdersCustomStringIdGenerator")
     @Id
     @Column(name = "order_id")
     private String orderId;

--- a/src/main/java/com/lifespace/repository/OrdersRepository.java
+++ b/src/main/java/com/lifespace/repository/OrdersRepository.java
@@ -6,6 +6,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import java.sql.Timestamp;
+import java.util.List;
+
 
 public interface OrdersRepository extends JpaRepository<Orders, String> {
 
@@ -13,4 +16,10 @@ public interface OrdersRepository extends JpaRepository<Orders, String> {
     @Modifying
     @Query(value = "UPDATE orders SET order_status = ?1 WHERE order_id = ?2", nativeQuery = true)
     void updateOrderStatusByOrderId(Integer orderStatus, String orderId);
+
+    List<Orders> findByOrderStatusAndOrderEndBefore(Integer orderStatus, Timestamp OrderEnd );
+
+
 }
+
+

--- a/src/main/resources/static/css/orders.css
+++ b/src/main/resources/static/css/orders.css
@@ -142,3 +142,12 @@ body {
     overflow-x: hidden !important;
 }
 
+.btn-primary{
+    background-color: #E0F2F1;
+    color: #20B2AA;
+    border: none;
+    border-radius: 4px;
+    padding: 6px 12px;
+    font-size: 14px;
+}
+

--- a/src/main/resources/static/orders.html
+++ b/src/main/resources/static/orders.html
@@ -74,6 +74,15 @@
     </div>
   </div>
 </div>
+<!-- 錯誤訊息 Modal -->
+<div class="modal fade" id="errorModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content text-center p-4">
+      <p id="modal-error-message" class="mb-3 fs-5 fw-bold text-dark" ></p>
+      <button type="button" class="btn-primary" data-bs-dismiss="modal">確定</button>
+    </div>
+  </div>
+</div>
 
 <!-- jQuery -->
 <script src="/vendors/jquery/jquery-3.7.1.min.js"></script>
@@ -176,13 +185,17 @@
       $.ajax({
         url: `/orders/cancel/${orderId}`,
         type: 'POST',
-        success: function () {
-          alert('已取消訂單');
+        success: function (msg) {
+          alert(msg);
           $('#ordersTable').DataTable().ajax.reload(); // 重新載入表格
         },
-        error: function () {
-          alert('取消失敗，請稍後再試');
-          button.prop('disabled', false); // 失敗時重新啟用按鈕
+        error: function (xhr) {
+          const errorMsg = xhr.responseText || '取消失敗';
+
+          $('#modal-error-message').text(errorMsg);
+          $('#errorModal').modal('show');
+
+          button.prop('disabled', false);
         }
       });
     }


### PR DESCRIPTION
新增 Orders後端 取消訂單錯誤驗證(及前端點選取消訂單的驗證錯誤彈窗)/
        訂單已完成狀態的更新排程器/
        開啟Application檢查訂單狀態是否正確更新並刷新/
        刪除pom檔重複的javax.validation留下jakarta.validation